### PR TITLE
Polishing

### DIFF
--- a/FistBump/views/components/payments/Paywall/PaywallAdvance.jsx
+++ b/FistBump/views/components/payments/Paywall/PaywallAdvance.jsx
@@ -175,10 +175,10 @@ flexGrow:1
     flex: 1
   },
   imgContainer: {
-    paddingTop: height*0.1,
-    width: width,
-paddingBottom:height*0.1,
-    height: height*0.45
+    flex: 1,
+    width: '100%',
+    height: '50%',
+    alignItems: 'center'
   },
   otherContainer: {
     display: 'flex',
@@ -202,7 +202,6 @@ paddingBottom:height*0.1,
     fontSize: 20,
     fontWeight: "800",
     lineHeight: 25,
-    paddingTop: 0.03*height
   },
   button: {
     marginTop: '10%',
@@ -210,7 +209,7 @@ paddingBottom:height*0.1,
     width: width*0.7,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'rgb(233, 60, 6)',
+    backgroundColor: 'green',
     shadowColor: 'rgba(0,0,0,0.4)',
     borderRadius: 50,
     shadowOffset: {
@@ -228,7 +227,7 @@ paddingBottom:height*0.1,
     width: width*0.7,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'green',
+    backgroundColor: 'rgb(233, 60, 6)',
     shadowColor: 'rgba(0,0,0,0.4)',
     borderRadius: 50,
     shadowOffset: {
@@ -247,9 +246,11 @@ paddingBottom:height*0.1,
   },
   logoImage: {
     width: '100%',
-    height: undefined,
-    aspectRatio: 1,
-    overflow: 'visible'
+    height: '100%',
+    ...Platform.select({
+      ios: { aspectRatio: 120/76 },
+      android: { aspectRatio: 1 }
+    })
   },
   title: {
     fontSize: 16,

--- a/FistBump/views/components/payments/Paywall/PaywallAdvance.jsx
+++ b/FistBump/views/components/payments/Paywall/PaywallAdvance.jsx
@@ -248,7 +248,7 @@ paddingBottom:height*0.1,
   logoImage: {
     width: '100%',
     height: undefined,
-    aspectRatio: 120/76,
+    aspectRatio: 1,
     overflow: 'visible'
   },
   title: {

--- a/FistBump/views/mainGame/MainGame.jsx
+++ b/FistBump/views/mainGame/MainGame.jsx
@@ -99,7 +99,7 @@ export function MainGame() {
             
            bellSound.stop()
             //initialSound.release()
-        }, 3000)
+        }, 1000)
         setTimeout(() => {
             handlePunch()
         }, actionImage.image==19?1000:100)


### PR DESCRIPTION
Small enhacement ideas:

Aspect ration 120/76 in the Paywall screen was causing on Android the Logo to be cut from the top.
Aspect Ratio 1 fixes it for the case of Samsung A14. If the ratio is breaking on iPhone - we can leave it out.


For the bell - I tested it with 1 second of sound and I think it looks good.